### PR TITLE
chore: add project authors to package.json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENTS.md
+
+## Purpose
+`node-cubrid` is a legacy Node.js driver for CUBRID with callback and promise APIs.
+
+## Read First
+- `README.md`
+- `docs/agent-playbook.md`
+
+## Working Rules
+- Preserve backward compatibility unless the task explicitly targets a breaking change.
+- Keep callback and promise examples aligned with the implementation.
+- Avoid modernizing runtime assumptions casually; this repository still documents legacy Node support.
+- Update README when connection, query, or transaction contracts change.
+
+## Validation
+- `npm test`
+- `npm run lint`
+- `npm run coverage`

--- a/docs/agent-playbook.md
+++ b/docs/agent-playbook.md
@@ -1,0 +1,22 @@
+# Agent Playbook
+
+## Source Of Truth
+- `README.md` for public API, runtime expectations, and test prerequisites.
+- `package.json` for canonical scripts and dependency constraints.
+
+## Repository Map
+- `src/` driver implementation.
+- `test/` integration-style test suite.
+- Root docs define runtime and local database assumptions.
+
+## Change Workflow
+1. Confirm whether the change affects protocol behavior, query APIs, or documentation only.
+2. Preserve existing method signatures and error paths unless a breaking change is explicitly intended.
+3. Keep both callback and promise examples accurate when behavior changes.
+4. Run tests against a local or containerized CUBRID instance when touching connection and query code.
+
+## Validation
+- `npm install`
+- `npm test`
+- `npm run coverage`
+- Use the Docker workflow from `README.md` if a local CUBRID server is not already running

--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "name": "node-cubrid",
   "version": "11.0.0",
   "description": "This is a Node.js driver for CUBRID RDBMS. It is developed in 100% JavaScript and does not require specific platform compilation.",
-  "author": "CUBRID <contact@cubrid.org> (http://www.cubrid.org/)",
+  "author": "Gyeongjun Paik <paikend@gmail.com>",
+  "contributors": [
+    { "name": "Gyeongjun Paik", "email": "paikend@gmail.com" },
+    { "name": "Yeongseon Choe", "email": "yeongseon.choe@gmail.com" }
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/cubrid/node-cubrid.git"


### PR DESCRIPTION
## Summary

- Replace generic `CUBRID <contact@cubrid.org>` author with individual maintainer names
- Add `contributors` field with both maintainers

Closes #65